### PR TITLE
[BUGFIX] Handle legacy init events (#45)

### DIFF
--- a/packages/core/src/compat.ts
+++ b/packages/core/src/compat.ts
@@ -7,7 +7,11 @@ export function handleLegacyLibResizeMessage(event: MessageEvent): number | null
     return null;
   }
 
-  if (!event.data.endsWith("mutationObserver") && !event.data.endsWith("resizeObserver")) {
+  // newer versions also append the child's version number on the init event
+  if (
+    !(event.data.search(/:init(:[\d.]+)?$/g) >= 0) &&
+    !event.data.endsWith("mutationObserver") && !event.data.endsWith("resizeObserver")
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Fixes #38.

The legacy package sends an init event after negotiation, which includes the initial height/width snapshot. PR #20 filtered out this event. However, what ends up happening is neither child observer gets triggered on document load and needs to wait for one of them to fire before the first resize can happen (which usually requires user input to trigger, like the scrolling in the frame).

Also, modern versions of `iframe-resizer` include the child version in the init event `[iFrameSizer]ID:277:540:init:5.4.7`, so this needs to handle init events with and without the version.