### PR TITLE
[FIX] Enable height updates for in-iframe navigation

### DIFF
--- a/packages/core/src/parent.ts
+++ b/packages/core/src/parent.ts
@@ -144,10 +144,22 @@ function addCrossOriginChildResizeListener(registeredElement: RegisteredElement,
     initContext.retryTimeoutId = window.setTimeout(sendInitializationMessageToChild, getExponentialBackoffDelay(initContext.retryAttempts));
   };
 
+  const handleNavigation = () => {
+    if (initContext.isInitialized) {
+      initContext.isInitialized = false;
+      initContext.retryAttempts = 0;
+      sendInitializationMessageToChild();
+    }
+  };
+
+  iframe.addEventListener("load", handleNavigation);
   sendInitializationMessageToChild();
 
   return {
-    unsubscribe: () => window.removeEventListener("message", handleIframeResizedMessage),
+    unsubscribe: () => {
+      window.removeEventListener("message", handleIframeResizedMessage);
+      iframe.removeEventListener("load", handleNavigation);
+    },
     resize: () => {
       const message: IframeGetChildDimensionsEventData = { type: "iframe-get-child-dimensions" };
       iframe.contentWindow?.postMessage(message, "*");


### PR DESCRIPTION
Fixes #46.
 
### What
Adds a persistent `load` listener in `addCrossOriginChildResizeListener()` that re-sends `iframe-child-init` to the child page whenever the iframe navigates to a new page.

### Why
When a cross-origin iframe contains multiple pages linked via normal anchor tags, height updates stop working after the first navigation. After the first successful handshake, `initContext.isInitialized` is set to `true` and the retry loop stops permanently. Any subsequent in-iframe navigation loads a fresh child script instance that waits for `iframe-child-init` — but since the retry loop has stopped and `postMessageSafelyToCrossOriginIframe()`'s `{ once: true }` listener is already consumed, the message is never delivered. The child never sets up its `ResizeObserver` and height updates stop entirely.

### How
```typescript
const handleNavigation = () => {
  if (initContext.isInitialized) {
    initContext.isInitialized = false;
    initContext.retryAttempts = 0;
    sendInitializationMessageToChild();
  }
};

iframe.addEventListener("load", handleNavigation);

// in unsubscribe:
iframe.removeEventListener("load", handleNavigation);
```

The `if (initContext.isInitialized)` guard ensures no conflict with the initial retry loop. Cleanup is handled in `unsubscribe()` to prevent memory leaks.