### PR TITLE
Add Angular 22 peer dependency support

### DIFF
--- a/packages/angular/projects/lib/package-lock.json
+++ b/packages/angular/projects/lib/package-lock.json
@@ -9,52 +9,61 @@
 			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
-				"@open-iframe-resizer/core": "2.2.0",
+				"@open-iframe-resizer/core": "2.4.0",
 				"tslib": "^2.3.0"
 			},
 			"peerDependencies": {
-				"@angular/common": ">=14.0.0 <21.0.0",
-				"@angular/core": ">=14.0.0 <21.0.0"
+				"@angular/common": ">=14.0.0 <23.0.0",
+				"@angular/core": ">=14.0.0 <23.0.0"
 			}
 		},
 		"node_modules/@angular/common": {
-			"version": "19.2.17",
-			"resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.17.tgz",
-			"integrity": "sha512-yFUXAdpvOFirGD/EGDwp1WHravHzI4sdyRE2iH7i8im9l8IE2VZ6D1KDJp8VVpMJt38LNlRAWYek3s+z6OcAkg==",
+			"version": "22.1.1",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.1.tgz",
+			"integrity": "sha512-5iiyPWqO3acpOPMcJWYtVbXF5z9wy43MFQQdd7wZPHfYOIC7c3KRnziWrRpELae+SkEB4srAYr6XIu9rQ743nw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
 			"engines": {
-				"node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+				"node": "^22.22.3 || ^24.15.0 || >=26.0.0"
 			},
 			"peerDependencies": {
-				"@angular/core": "19.2.17",
+				"@angular/core": "22.1.1",
 				"rxjs": "^6.5.3 || ^7.4.0"
 			}
 		},
 		"node_modules/@angular/core": {
-			"version": "19.2.17",
-			"resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.17.tgz",
-			"integrity": "sha512-nVu0ryxfiXUZ9M+NV21TY+rJZkPXTYo9U0aJb19hvByPpG+EvuujXUOgpulz6vxIzGy7pz/znRa+K9kxuuC+yQ==",
+			"version": "22.1.1",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.1.tgz",
+			"integrity": "sha512-QFZNFzyFw9l1B1D7NCEU3YiLLBnMSejyp9mzJrzZ9vzc70BsewikcLFwuj+qqleqFmi5VW3f9GFNgwUq8dWGAg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
 			"engines": {
-				"node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+				"node": "^22.22.3 || ^24.15.0 || >=26.0.0"
 			},
 			"peerDependencies": {
+				"@angular/compiler": "22.1.1",
 				"rxjs": "^6.5.3 || ^7.4.0",
-				"zone.js": "~0.15.0"
+				"zone.js": "~0.15.0 || ~0.16.0"
+			},
+			"peerDependenciesMeta": {
+				"@angular/compiler": {
+					"optional": true
+				},
+				"zone.js": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@open-iframe-resizer/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@open-iframe-resizer/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-ujtYbkNQG7OJbOeplaAGEETRiXA/xyhI9D0nlayAm5jhZx1y0/1/hk/H5l9cSHbqtFdnmlorDZsuVjCpVdy31g==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@open-iframe-resizer/core/-/core-2.4.0.tgz",
+			"integrity": "sha512-cTT1+ithuaXCftiZ8CNoxvPemsXV1p+Vnh/klFbt4qt6OisipIXJ0RnnNM64zzbTWZRZRJbyLJWSSY8PRBmbFA==",
 			"license": "MIT"
 		},
 		"node_modules/rxjs": {
@@ -72,13 +81,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
-		},
-		"node_modules/zone.js": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-			"integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-			"license": "MIT",
-			"peer": true
 		}
 	}
 }

--- a/packages/angular/projects/lib/package.json
+++ b/packages/angular/projects/lib/package.json
@@ -22,8 +22,8 @@
 		"angular"
 	],
 	"peerDependencies": {
-		"@angular/common": ">=14.0.0 <22.0.0",
-		"@angular/core": ">=14.0.0 <22.0.0"
+		"@angular/common": ">=14.0.0 <23.0.0",
+		"@angular/core": ">=14.0.0 <23.0.0"
 	},
 	"dependencies": {
 		"@open-iframe-resizer/core": "2.4.0",


### PR DESCRIPTION
Bumps the Angular peer dependency range from `<22.0.0` to `<23.0.0` to support Angular 22.                                                                 
                
The demo app remains on Angular 19 as this is a peer dep range update only.   